### PR TITLE
Fix crash when no permissions for scanning are granted

### DIFF
--- a/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
+++ b/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
@@ -53,31 +53,35 @@ class PaymentSampleAppFragment : Fragment() {
         binding.buttonPayNyc1.setOnClickListener {
             uiScope.launch {
                 InPersonPayments.getPaymentInterface(PaymentInterfaceType.CardReader())
-                    .onSuccess { nyc1Interface ->
-                        startPayment(nyc1Interface)
-                    }
-                    .onFailure {
-                        Toast.makeText(
-                            requireContext(),
-                            R.string.toast_no_bt_permissions,
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
+                    .fold(
+                        onSuccess = { nyc1Interface ->
+                            startPayment(nyc1Interface)
+                        },
+                        onFailure = {
+                            Toast.makeText(
+                                requireContext(),
+                                R.string.toast_no_bt_permissions,
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    )
             }
         }
         binding.buttonPayT2p.setOnClickListener {
             uiScope.launch {
                 InPersonPayments.getPaymentInterface(PaymentInterfaceType.TapToPay)
-                    .onSuccess { t2pInterface ->
-                        startPayment(t2pInterface)
-                    }
-                    .onFailure {
-                        Toast.makeText(
-                            requireContext(),
-                            R.string.toast_t2p_interface_creation_failed,
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
+                    .fold(
+                        onSuccess = { t2pInterface ->
+                            startPayment(t2pInterface)
+                        },
+                        onFailure = {
+                            Toast.makeText(
+                                requireContext(),
+                                R.string.toast_t2p_interface_creation_failed,
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    )
             }
         }
     }

--- a/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
+++ b/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
@@ -14,14 +14,14 @@ import com.adyen.ipp.payment.PaymentInterface
 import com.adyen.ipp.payment.PaymentInterfaceType
 import com.adyen.ipp.payment.TransactionRequest
 import com.adyen.sampleapp.databinding.FragmentPaymentBinding
-import java.util.Date
-import java.util.Locale
-import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import logcat.logcat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
 
 /**
  * A simple [Fragment] subclass as the default destination in the navigation.
@@ -34,7 +34,7 @@ class PaymentSampleAppFragment : Fragment() {
     private val resultLauncher = InPersonPayments.registerForPaymentResult(this) { paymentResult ->
         val resultText = if (paymentResult.success) "Payment Successful" else "Payment Failed"
         Toast.makeText(requireContext(), resultText, Toast.LENGTH_LONG).show()
-        logcat(tag = logTag) { "Result: \n ${paymentResult.data.decodeFromBase64String()}"}
+        logcat(tag = logTag) { "Result: \n ${paymentResult.data.decodeFromBase64String()}" }
     }
 
     private val job = Job()
@@ -52,14 +52,28 @@ class PaymentSampleAppFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.buttonPayNyc1.setOnClickListener {
             uiScope.launch {
-                val nyc1Interface = InPersonPayments.getPaymentInterface(PaymentInterfaceType.CardReader())
-                startPayment(nyc1Interface.getOrThrow())
+                val nyc1Interface =
+                    InPersonPayments.getPaymentInterface(PaymentInterfaceType.CardReader())
+                nyc1Interface.getOrNull()?.let {
+                    startPayment(it)
+                } ?: Toast.makeText(
+                    requireContext(),
+                    R.string.toast_no_bt_permissions,
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
         binding.buttonPayT2p.setOnClickListener {
             uiScope.launch {
-                val t2pInterface = InPersonPayments.getPaymentInterface(PaymentInterfaceType.TapToPay)
-                startPayment(t2pInterface.getOrThrow())
+                val t2pInterface =
+                    InPersonPayments.getPaymentInterface(PaymentInterfaceType.TapToPay)
+                t2pInterface.getOrNull()?.let {
+                    startPayment(it)
+                }?: Toast.makeText(
+                    requireContext(),
+                    R.string.toast_t2p_interface_creation_failed,
+                    Toast.LENGTH_LONG
+                ).show()
             }
         }
     }

--- a/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
+++ b/app/src/main/java/com/adyen/sampleapp/PaymentSampleAppFragment.kt
@@ -52,28 +52,32 @@ class PaymentSampleAppFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.buttonPayNyc1.setOnClickListener {
             uiScope.launch {
-                val nyc1Interface =
-                    InPersonPayments.getPaymentInterface(PaymentInterfaceType.CardReader())
-                nyc1Interface.getOrNull()?.let {
-                    startPayment(it)
-                } ?: Toast.makeText(
-                    requireContext(),
-                    R.string.toast_no_bt_permissions,
-                    Toast.LENGTH_LONG
-                ).show()
+                InPersonPayments.getPaymentInterface(PaymentInterfaceType.CardReader())
+                    .onSuccess { nyc1Interface ->
+                        startPayment(nyc1Interface)
+                    }
+                    .onFailure {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.toast_no_bt_permissions,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
             }
         }
         binding.buttonPayT2p.setOnClickListener {
             uiScope.launch {
-                val t2pInterface =
-                    InPersonPayments.getPaymentInterface(PaymentInterfaceType.TapToPay)
-                t2pInterface.getOrNull()?.let {
-                    startPayment(it)
-                }?: Toast.makeText(
-                    requireContext(),
-                    R.string.toast_t2p_interface_creation_failed,
-                    Toast.LENGTH_LONG
-                ).show()
+                InPersonPayments.getPaymentInterface(PaymentInterfaceType.TapToPay)
+                    .onSuccess { t2pInterface ->
+                        startPayment(t2pInterface)
+                    }
+                    .onFailure {
+                        Toast.makeText(
+                            requireContext(),
+                            R.string.toast_t2p_interface_creation_failed,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
 
     <string name="first_fragment_connect_to_device">Connect to the device first.</string>
     <string name="first_fragment_default_payment">Default payment is €5</string>
+
+    <string name="toast_no_bt_permissions">Check your Bluetooth permissions.</string>
+    <string name="toast_t2p_interface_creation_failed">Something went wrong.</string>
 </resources>


### PR DESCRIPTION
## Summary
- Check the result of creating a payment interface to avoid the crash

## Tested scenarios
- Fresh install the app -> click on Pay with Card Reader -> No crash should happen, but a toast instead should be displayerd
